### PR TITLE
fix: get injected provider when dependency is null or undefined

### DIFF
--- a/lib/with-transaction.ts
+++ b/lib/with-transaction.ts
@@ -1,7 +1,7 @@
-import { Injectable } from '@nestjs/common';
-import { EntityManager, Repository } from 'typeorm';
-import { ModuleRef } from '@nestjs/core';
-import { PARAMTYPES_METADATA } from '@nestjs/common/constants';
+import { Injectable } from "@nestjs/common";
+import { EntityManager, Repository } from "typeorm";
+import { ModuleRef } from "@nestjs/core";
+import { PARAMTYPES_METADATA } from "@nestjs/common/constants";
 
 type ClassType<T = any> = new (...args: any[]) => T;
 type ForwardRef = {
@@ -22,8 +22,7 @@ export interface WithTransactionOptions {
 export class TransactionFor<T = any> {
   private cache: Map<string, any> = new Map();
 
-  constructor(private moduleRef: ModuleRef) {
-  }
+  constructor(private moduleRef: ModuleRef) {}
 
   public withTransaction(manager: EntityManager, transactionOptions: WithTransactionOptions = {}): this {
     const newInstance = this.findArgumentsForProvider(this.constructor as ClassType<this>, manager, transactionOptions.excluded ?? []);
@@ -32,10 +31,10 @@ export class TransactionFor<T = any> {
   }
 
   private getArgument(param: string | ClassType | ForwardRef, manager: EntityManager, excluded: ClassType[]): any {
-    if (typeof param === 'object' && 'forwardRef' in param) {
+    if (typeof param === "object" && "forwardRef" in param) {
       return this.moduleRef.get(param.forwardRef().name, { strict: false });
     }
-    const id = typeof param === 'string' ? param : typeof param === 'function' ? param.name : undefined;
+    const id = typeof param === "string" ? param : typeof param === "function" ? param.name : undefined;
     if (id === undefined) {
       throw new Error(`Can't get injection token from ${param}`);
     }
@@ -51,8 +50,8 @@ export class TransactionFor<T = any> {
     if (this.cache.has(id)) {
       return this.cache.get(id);
     }
-    const canBeRepository = id.includes('Repository');
-    if (typeof param === 'string' || canBeRepository) {
+    const canBeRepository = id.includes("Repository");
+    if (typeof param === "string" || canBeRepository) {
       // Fetch the dependency
       let dependency: Repository<any>;
       try {
@@ -68,6 +67,10 @@ export class TransactionFor<T = any> {
         const entity: any = dependency!.metadata.target;
         argument = manager.getRepository(entity);
       } else {
+        if (!dependency) {
+          dependency = this.moduleRef.get(param, { strict: false });
+        }
+
         // The dependency is not a repository, use it directly.
         argument = dependency!;
       }


### PR DESCRIPTION
Hi Mike,
Thank you for providing this helpful package for community!
Currently there is problem when I want to inject a provider through the use of `@Inject`, for example: `@Inject('sample-service')`, dependency is null. I have created this PR to fix that problem. Please take a look.

Best regards.