### PR TITLE
Fix resolving a provider that is injected using forwardRef

### DIFF
--- a/example/src/circular/circular.module.ts
+++ b/example/src/circular/circular.module.ts
@@ -1,0 +1,10 @@
+import { forwardRef, Module } from '@nestjs/common';
+import { CommonModule } from '../common/common.module';
+import { CircularService } from './circular.service';
+
+@Module({
+  imports: [forwardRef(() => CommonModule)],
+  providers: [CircularService],
+  exports: [CircularService],
+})
+export class CircularModule { }

--- a/example/src/circular/circular.service.ts
+++ b/example/src/circular/circular.service.ts
@@ -1,0 +1,15 @@
+import { forwardRef, Inject, Injectable } from '@nestjs/common';
+import { ModuleRef } from '@nestjs/core';
+import { TransactionFor } from '../../../lib/with-transaction';
+import { CommonService } from '../common/common.service';
+
+@Injectable()
+export class CircularService extends TransactionFor<CircularService> {
+  constructor(
+    @Inject(forwardRef(() => CommonService))
+    private commonService: CommonService,
+    moduleRef: ModuleRef,
+  ) {
+    super(moduleRef);
+  }
+}

--- a/example/src/common/common.module.ts
+++ b/example/src/common/common.module.ts
@@ -1,0 +1,12 @@
+import { forwardRef, Module } from '@nestjs/common';
+import { CircularModule } from '../circular/circular.module';
+import { CommonService } from './common.service';
+
+@Module({
+  imports: [
+    forwardRef(() => CircularModule),
+  ],
+  providers: [CommonService],
+  exports: [CommonService],
+})
+export class CommonModule { }

--- a/example/src/common/common.service.ts
+++ b/example/src/common/common.service.ts
@@ -1,0 +1,10 @@
+import { forwardRef, Inject, Injectable } from '@nestjs/common';
+import { CircularService } from '../circular/circular.service';
+
+@Injectable()
+export class CommonService {
+  constructor(
+    @Inject(forwardRef(() => CircularService))
+    private circularService: CircularService
+  ) { }
+}

--- a/example/src/example-app.module.ts
+++ b/example/src/example-app.module.ts
@@ -6,6 +6,7 @@ import { TransferModule } from './transfer/transfer.module';
 import { PushNotificationModule } from './push-notification/push-notification.module';
 import { InfoController } from './transfer/info.controller';
 import { InfoService } from './transfer/info.service';
+import { CacheService } from './transfer/cache.service';
 
 @Module({
   imports: [
@@ -15,7 +16,7 @@ import { InfoService } from './transfer/info.service';
     PushNotificationModule,
   ],
   controllers: [InfoController],
-  providers: [InfoService],
+  providers: [CacheService, InfoService],
 })
 export class ExampleAppModule {
 }

--- a/example/src/example-app.module.ts
+++ b/example/src/example-app.module.ts
@@ -7,6 +7,8 @@ import { PushNotificationModule } from './push-notification/push-notification.mo
 import { InfoController } from './transfer/info.controller';
 import { InfoService } from './transfer/info.service';
 import { CacheService } from './transfer/cache.service';
+import { CircularModule } from './circular/circular.module';
+import { CommonModule } from './common/common.module';
 
 @Module({
   imports: [
@@ -14,6 +16,8 @@ import { CacheService } from './transfer/cache.service';
     UserModule,
     TransferModule,
     PushNotificationModule,
+    CircularModule,
+    CommonModule,
   ],
   controllers: [InfoController],
   providers: [CacheService, InfoService],

--- a/example/test/nest-transact.spec.ts
+++ b/example/test/nest-transact.spec.ts
@@ -5,6 +5,8 @@ import * as request from 'supertest';
 import { isNotDefined } from '../src/tools';
 import { constants } from 'http2';
 import { TransferParamsDTO } from '../src/transfer/dto/transfer-params.dto';
+import { CircularService } from '../src/circular/circular.service';
+import { DataSource } from 'typeorm';
 
 describe('Nest Transact E2E Testing', () => {
   let app: INestApplication;
@@ -75,6 +77,15 @@ describe('Nest Transact E2E Testing', () => {
     expect(errorResult.statusCode).toBe(constants.HTTP_STATUS_TEAPOT);
     expect(sumOfResponse(okResult.body)).toBe(1900);
   });
+
+  it('Import modules using forwardRef', async () => {
+    const service = app.get(CircularService);
+    const dataSource = app.get(DataSource);
+
+    await dataSource.transaction(async manager => {
+      service.withTransaction(manager);
+    });
+  })
 
   afterAll(async () => {
     await app.close();

--- a/lib/with-transaction.ts
+++ b/lib/with-transaction.ts
@@ -34,7 +34,7 @@ export class TransactionFor<T = any> {
 
   private getArgument(param: string | ClassType | ForwardRef, manager: EntityManager, excluded: ClassType[]): any {
     if (typeof param === 'object' && 'forwardRef' in param) {
-      return this.moduleRef.get(param.forwardRef().name, { strict: false });
+      return this.moduleRef.get(param.forwardRef(), { strict: false });
     }
     const id = typeof param === 'string' ? param : typeof param === 'function' ? param.name : undefined;
     if (id === undefined) {


### PR DESCRIPTION
Hi @alphamikle,

I found an issue when a service is injected using `forwardRef` for example `@Inject(forwardRef(() => CommonService))`, in this case Nest fails to find the service with the eror:

> Nest could not find CommonService element (this provider does not exist in the current context)

Based on the [Nest module-ref docs](https://docs.nestjs.com/fundamentals/module-ref#retrieving-instances), it seems that `moduleRef.get(Service)` is expecting to be called with the class, rather than it's name.

I have created a PR to fix this (a933f8d42a1b4e49e897f467d1c8e4c9f38c06f2) and included a test in the `example` folder (eaea4cd595b86366b0f80e9c2fcb8a9168ed3ed9).

`npm run test` failed for me initially, until I added `CacheService` to the `ExampleAppModule.providers` (a3ec991263e350e3cc4571f44fd84f8afa96ab46)

Thanks for providing a great library. 

